### PR TITLE
Add method to handle defunct ticker, adjust rate gate, and default processing start data

### DIFF
--- a/DataProcessing/Program.cs
+++ b/DataProcessing/Program.cs
@@ -31,8 +31,7 @@ namespace QuantConnect.DataProcessing
         /// <returns>Exit code. 0 equals successful, and any other value indicates the downloader/converter failed.</returns>
         public static void Main()
         {
-            Config.Set("data-folder", "C:\\Users\\Alex\\LeanCLI\\data");
-            Config.Set("processing-start-date", "20180101");
+            Config.Set("processing-start-date", "20140101");
 
             // Get the config values first before running. These values are set for us
             // automatically to the value set on the website when defining this data type

--- a/DataProcessing/Program.cs
+++ b/DataProcessing/Program.cs
@@ -31,8 +31,6 @@ namespace QuantConnect.DataProcessing
         /// <returns>Exit code. 0 equals successful, and any other value indicates the downloader/converter failed.</returns>
         public static void Main()
         {
-            Config.Set("processing-start-date", "20140101");
-
             // Get the config values first before running. These values are set for us
             // automatically to the value set on the website when defining this data type
             var destinationDirectory = System.IO.Path.Combine(
@@ -47,7 +45,8 @@ namespace QuantConnect.DataProcessing
             processingEndDateValue ??= DateTime.Today.ToString("yyyyMMdd");
             var processingEndDate = Parse.DateTimeExact(processingEndDateValue, "yyyyMMdd");
 
-            var processingStartDateValue = Config.Get("processing-start-date", processingEndDateValue);
+            var processingStartDateValue = Config.Get("processing-start-date", Environment.GetEnvironmentVariable("QUIVER_INSIDER_START_DATE"));
+            processingEndDateValue ??= DateTime.Today.ToString("yyyyMMdd");
             var processingStartDate = Parse.DateTimeExact(processingStartDateValue, "yyyyMMdd");
 
             QuiverInsiderTradingDataDownloader instance = null;

--- a/DataProcessing/QuiverInsiderTradingDataDownloader.cs
+++ b/DataProcessing/QuiverInsiderTradingDataDownloader.cs
@@ -49,6 +49,13 @@ namespace QuantConnect.DataProcessing
         private readonly bool _canCreateUniverseFiles;
         private readonly string _clientKey;
         private readonly int _maxRetries = 5;
+        private static readonly List<char> _defunctDelimiters = new()
+        {
+            '-',
+            '_',
+            '+',
+            '|'
+        };
 
         private readonly JsonSerializerSettings _jsonSerializerSettings = new ()
         {
@@ -146,7 +153,7 @@ namespace QuantConnect.DataProcessing
                     }
                     var sid = SecurityIdentifier.GenerateEquity(ticker, Market.USA, true, mapFileProvider, processDate);
 
-                    if (sid.Date == Time.BeginningOfTime) continue;
+                    if (sid.Date == Time.BeginningOfTime || sid.ToString().Contains(" 2T")) continue;
 
                     if (!insiderTradingByTicker.TryGetValue(ticker, out var _))
                     {
@@ -286,7 +293,7 @@ namespace QuantConnect.DataProcessing
         /// <returns>true for success, false for failure</returns>
         private static bool TryNormalizeDefunctTicker(string rawTicker, out string nonDefunctTicker)
         {
-            ticker = rawTicker.Split(':').Last().Replace("\"", string.Empty).ToUpperInvariant().Trim();
+            var ticker = rawTicker.Split(':').Last().Replace("\"", string.Empty).ToUpperInvariant().Trim();
             // The "defunct" indicator can be in any capitalization/case
             if (ticker.IndexOf("defunct", StringComparison.OrdinalIgnoreCase) > 0)
             {


### PR DESCRIPTION
- Set default start date from 20140101
- Adjust the rate gate to allow 2 HTML requests per second
- Add handler for defunct ticker
- Set the default start-process-date from an environmental variable